### PR TITLE
Add whitelist feature for context routes and actuators

### DIFF
--- a/src/RouteServiceAuth/Constants.cs
+++ b/src/RouteServiceAuth/Constants.cs
@@ -1,0 +1,7 @@
+namespace RouteServiceAuth
+{
+    public static class Constants
+    {
+        public const string X_CF_Forwarded_Url = "X-CF-Forwarded-Url";
+    }
+}

--- a/src/RouteServiceAuth/Extensions.cs
+++ b/src/RouteServiceAuth/Extensions.cs
@@ -3,25 +3,16 @@ using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.Logging;
 using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Options;
 
 namespace RouteServiceAuth
 {
     public static class Extensions
     {
-        public static IServiceCollection AddWhitelist(this IServiceCollection services, IConfiguration configuration, ILoggerFactory loggerFactory)
+        public static IServiceCollection AddWhitelist(this IServiceCollection services, IConfiguration configuration, string sectionName = "Whitelist")
         {
-            var whitelist = new Whitelist(loggerFactory);
-            var section = configuration.GetSection("whitelist");
-            var scope = "whitelist =====>";
-            var logger = loggerFactory.CreateLogger("Whitelist Configurator");
-            logger.LogDebug(scope);
-            foreach(var child in section.GetChildren())
-            {
-                var entry = whitelist.CreateEntry(child.Value);
-                whitelist.Entries.Add(entry);
-                logger.LogDebug($"{scope} Added {entry}");
-            }
-            services.AddSingleton<IWhitelist>(whitelist);
+            services.Configure<WhitelistOptions>(configuration.GetSection(sectionName));
+            services.AddSingleton<IWhitelist, Whitelist>();
             return services;
         }
 

--- a/src/RouteServiceAuth/Extensions.cs
+++ b/src/RouteServiceAuth/Extensions.cs
@@ -1,0 +1,38 @@
+using System;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging;
+using Microsoft.AspNetCore.Http;
+
+namespace RouteServiceAuth
+{
+    public static class Extensions
+    {
+        public static IServiceCollection AddWhitelist(this IServiceCollection services, IConfiguration configuration, ILoggerFactory loggerFactory)
+        {
+            var whitelist = new Whitelist(loggerFactory);
+            var section = configuration.GetSection("whitelist");
+            var scope = "whitelist =====>";
+            var logger = loggerFactory.CreateLogger("Whitelist Configurator");
+            logger.LogDebug(scope);
+            foreach(var child in section.GetChildren())
+            {
+                var entry = whitelist.CreateEntry(child.Value);
+                whitelist.Entries.Add(entry);
+                logger.LogDebug($"{scope} Added {entry}");
+            }
+            services.AddSingleton<IWhitelist>(whitelist);
+            return services;
+        }
+
+        public static bool TryGetForwardAddress(this IHeaderDictionary headers, out string forwardAddress)
+        {
+            forwardAddress = null;
+            if(headers.TryGetValue(Constants.X_CF_Forwarded_Url, out var values))
+            {
+                forwardAddress = values.ToString();
+            }
+            return null != forwardAddress;
+        }
+    }
+}

--- a/src/RouteServiceAuth/Properties/PublishProfiles/FolderProfile.pubxml
+++ b/src/RouteServiceAuth/Properties/PublishProfiles/FolderProfile.pubxml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <PropertyGroup>
+    <WebPublishMethod>FileSystem</WebPublishMethod>
+    <LastUsedBuildConfiguration>Release</LastUsedBuildConfiguration>
+    <LastUsedPlatform>AnyCPU</LastUsedPlatform>
+    <publishUrl>bin/Release/netcoreapp2.2/publish</publishUrl>
+    <DeleteExistingFiles>false</DeleteExistingFiles>
+    <TargetFramework>netcoreapp2.2</TargetFramework>
+    <SelfContained>false</SelfContained>
+    <_IsPortable>true</_IsPortable>
+  </PropertyGroup>
+</Project>

--- a/src/RouteServiceAuth/Properties/launchSettings.json
+++ b/src/RouteServiceAuth/Properties/launchSettings.json
@@ -4,7 +4,8 @@
       "commandName": "Project",
       "launchBrowser": true,
       "environmentVariables": {
-        "ASPNETCORE_ENVIRONMENT": "Development"
+        "ASPNETCORE_ENVIRONMENT": "Development",
+        "PRINCIPAL_PASSWORD": "SomePassword"
       },
       "applicationUrl": "http://localhost:5000"
     }

--- a/src/RouteServiceAuth/Properties/launchSettings.json
+++ b/src/RouteServiceAuth/Properties/launchSettings.json
@@ -1,14 +1,12 @@
 {
-  
   "profiles": {
-  
-    "RouteService": {
+    "RouteServiceAuth": {
       "commandName": "Project",
+      "launchBrowser": true,
       "environmentVariables": {
-        "Principal_Password": "New0rder",
         "ASPNETCORE_ENVIRONMENT": "Development"
       },
-      "applicationUrl": "https://localhost:5001;http://localhost:5000"
+      "applicationUrl": "http://localhost:5000"
     }
   }
 }

--- a/src/RouteServiceAuth/RouteServiceAuth.csproj
+++ b/src/RouteServiceAuth/RouteServiceAuth.csproj
@@ -1,14 +1,14 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
-
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>netcoreapp2.2</TargetFramework>
     <AspNetCoreHostingModel>InProcess</AspNetCoreHostingModel>
   </PropertyGroup>
-
   <ItemGroup>
     <PackageReference Include="Kerberos.NET" Version="2.7.508.1" />
-    <PackageReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.AspNetCore.App">
+      <PrivateAssets Condition="'%(PackageReference.Version)' == ''">all</PrivateAssets>
+      <Publish Condition="'%(PackageReference.Version)' == ''">true</Publish>
+    </PackageReference>
     <PackageReference Include="ProxyKit" Version="2.0.4" />
   </ItemGroup>
-
 </Project>

--- a/src/RouteServiceAuth/RouteServiceAuth.csproj
+++ b/src/RouteServiceAuth/RouteServiceAuth.csproj
@@ -11,4 +11,12 @@
     </PackageReference>
     <PackageReference Include="ProxyKit" Version="2.0.4" />
   </ItemGroup>
+  <ItemGroup>
+    <Content Condition="'$(ExcludeConfigFilesFromBuildOutput)'!='true'" Update="appsettings.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+    <Content Condition="'$(ExcludeConfigFilesFromBuildOutput)'!='true'" Update="appsettings.Development.json">
+      <CopyToOutputDirectory>Always</CopyToOutputDirectory>
+    </Content>
+  </ItemGroup>
 </Project>

--- a/src/RouteServiceAuth/Startup.cs
+++ b/src/RouteServiceAuth/Startup.cs
@@ -2,6 +2,7 @@
 using System.Linq;
 using System.Net;
 using System.Net.Http;
+using Microsoft.Extensions.Configuration;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Builder;
@@ -18,13 +19,17 @@ namespace RouteServiceAuth
     public class Startup
     {
         private readonly ILogger<Startup> _logger;
+        private readonly ILoggerFactory _loggerFactory;
 
-        const string X_CF_Forwarded_Url = "X-CF-Forwarded-Url";
+        private readonly IConfiguration _configuration;
+
         // This method gets called by the runtime. Use this method to add services to the container.
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
-        public Startup(ILogger<Startup> logger)
+        public Startup(ILogger<Startup> logger, IConfiguration configuration, ILoggerFactory loggerFactory)
         {
             _logger = logger;
+            _configuration = configuration;
+            _loggerFactory = loggerFactory;
         }
 
         public void ConfigureServices(IServiceCollection services)
@@ -38,7 +43,7 @@ namespace RouteServiceAuth
 //                    opt.EventsType = typeof(KerberosAuthenticationEvents);
 //                });
             services.AddSingleton<KerberosAuthenticationEvents>();
-
+            services.AddWhitelist(_configuration, _loggerFactory);
             services.AddProxy();
         }
 
@@ -51,25 +56,32 @@ namespace RouteServiceAuth
 //                app.UseDeveloperExceptionPage();
 //            }
 
+            var whitelist = app.ApplicationServices.GetRequiredService<IWhitelist>();
             app.UseAuthentication();
             app.Use(async (context, next) =>
             {
                 if (!context.User.Identity.IsAuthenticated)
                 {
-                    
-                    var authResult = await context.AuthenticateAsync(SpnegoAuthenticationDefaults.AuthenticationScheme);
-                    if (authResult.Succeeded)
+                    if(whitelist.IsWhitelisted(context.Request))
                     {
-                        _logger.LogDebug($"User {authResult.Principal.Identity.Name} successfully logged in");
-                        await context.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, authResult.Principal);
-                        context.User = authResult.Principal;
+                        _logger.LogInformation($"Allowing passthrough for whitelisted request {context.Request.Path}");
                     }
                     else
                     {
-                        _logger.LogDebug("User authentication failed, issuing WWW-Authenticate challenge");
-                        await context.ChallengeAsync(SpnegoAuthenticationDefaults.AuthenticationScheme
-                            , new AuthenticationProperties());
-                        return;
+                        var authResult = await context.AuthenticateAsync(SpnegoAuthenticationDefaults.AuthenticationScheme);
+                        if (authResult.Succeeded)
+                        {
+                            _logger.LogDebug($"User {authResult.Principal.Identity.Name} successfully logged in");
+                            await context.SignInAsync(CookieAuthenticationDefaults.AuthenticationScheme, authResult.Principal);
+                            context.User = authResult.Principal;
+                        }
+                        else
+                        {
+                            _logger.LogDebug("User authentication failed, issuing WWW-Authenticate challenge");
+                            await context.ChallengeAsync(SpnegoAuthenticationDefaults.AuthenticationScheme
+                                , new AuthenticationProperties());
+                            return;
+                        }
                     }
                 }
                 await next();
@@ -77,22 +89,28 @@ namespace RouteServiceAuth
             app.RunProxy(async context =>
             {
                 HttpResponseMessage response;
-                if (!context.Request.Headers.TryGetValue(X_CF_Forwarded_Url, out var forwardTo))
+                if (!context.Request.Headers.TryGetForwardAddress(out var forwardTo))
                 {
                     response = new HttpResponseMessage(HttpStatusCode.BadRequest)
                     {
-                        Content = new StringContent($"Required header {X_CF_Forwarded_Url} not present in the request")
+                        Content = new StringContent($"Required header {Constants.X_CF_Forwarded_Url} not present in the request")
                     };
-                    _logger.LogDebug($"Received request without {X_CF_Forwarded_Url} header");
+                    _logger.LogDebug($"Received request without {Constants.X_CF_Forwarded_Url} header");
                     return response;
                 }
-                
 
-                var forwardContext = context.ForwardTo(forwardTo.ToString());
+                var forwardContext = context.ForwardTo(forwardTo);
                 forwardContext.UpstreamRequest.RequestUri = new Uri(forwardTo);
                 
-                forwardContext.UpstreamRequest.Headers.Add("X-CF-Identity", context.User.Identity.Name);
-                forwardContext.UpstreamRequest.Headers.Remove("Authorization");
+                if(whitelist.IsWhitelisted(context.Request))
+                {
+                    _logger.LogInformation($"Allowing passthrough for whitelisted request {forwardTo}");
+                }
+                else
+                {
+                    forwardContext.UpstreamRequest.Headers.Add("X-CF-Identity", context.User.Identity.Name);
+                    forwardContext.UpstreamRequest.Headers.Remove("Authorization");
+                }
 
                 _logger.LogTrace("Headers sent downstream");
                 _logger.LogTrace("-----------------------");

--- a/src/RouteServiceAuth/Startup.cs
+++ b/src/RouteServiceAuth/Startup.cs
@@ -19,17 +19,15 @@ namespace RouteServiceAuth
     public class Startup
     {
         private readonly ILogger<Startup> _logger;
-        private readonly ILoggerFactory _loggerFactory;
 
         private readonly IConfiguration _configuration;
 
         // This method gets called by the runtime. Use this method to add services to the container.
         // For more information on how to configure your application, visit https://go.microsoft.com/fwlink/?LinkID=398940
-        public Startup(ILogger<Startup> logger, IConfiguration configuration, ILoggerFactory loggerFactory)
+        public Startup(ILogger<Startup> logger, IConfiguration configuration)
         {
             _logger = logger;
             _configuration = configuration;
-            _loggerFactory = loggerFactory;
         }
 
         public void ConfigureServices(IServiceCollection services)

--- a/src/RouteServiceAuth/Startup.cs
+++ b/src/RouteServiceAuth/Startup.cs
@@ -43,7 +43,7 @@ namespace RouteServiceAuth
 //                    opt.EventsType = typeof(KerberosAuthenticationEvents);
 //                });
             services.AddSingleton<KerberosAuthenticationEvents>();
-            services.AddWhitelist(_configuration, _loggerFactory);
+            services.AddWhitelist(_configuration);
             services.AddProxy();
         }
 

--- a/src/RouteServiceAuth/Whitelist.cs
+++ b/src/RouteServiceAuth/Whitelist.cs
@@ -19,7 +19,7 @@ namespace RouteServiceAuth
         private readonly ILogger _logger;
         private readonly IOptionsMonitor<WhitelistOptions> _optionsMonitor;
 
-        public List<Uri> Entries { get;} = new List<Uri>();
+        public List<Uri> Entries { get; private set; } = new List<Uri>();
 
         public Whitelist(ILogger<Whitelist> logger, IOptionsMonitor<WhitelistOptions> optionsMonitor)
         {
@@ -31,15 +31,15 @@ namespace RouteServiceAuth
 
         void Bind(WhitelistOptions options)
         {
-            Entries.Clear();
-
+            var entries = new List<Uri>();
             foreach(var absolutePath in options.Paths)
             {
                 var entry = CreateEntry(absolutePath);
                 _logger?.LogTrace($"Adding {absolutePath} as {entry}");
-                Entries.Add(entry);
+                entries.Add(entry);
             }
-            _logger?.LogTrace($"Bound {Entries.Count} entries to the whitelist");
+            Entries = entries;
+            _logger?.LogTrace($"Bound {entries.Count} entries to the whitelist");
         }
 
         public Uri CreateEntry(Uri source)

--- a/src/RouteServiceAuth/Whitelist.cs
+++ b/src/RouteServiceAuth/Whitelist.cs
@@ -1,0 +1,65 @@
+namespace RouteServiceAuth
+{
+    using System;
+    using System.Linq;
+    using System.Collections.Generic;
+    using Microsoft.AspNetCore.Http;
+    using Microsoft.Extensions.Logging;
+
+    public interface IWhitelist
+    {
+        bool IsWhitelisted(HttpRequest request);
+    }
+
+    public class Whitelist : IWhitelist
+    {
+        const string BaseAddress = "http://localhost";
+
+        public List<Uri> Entries { get;} = new List<Uri>();
+        private readonly ILogger _logger;
+
+        public Whitelist(ILoggerFactory loggerFactory)
+        {
+            _logger = loggerFactory?.CreateLogger<Whitelist>();
+        }
+
+        public Uri CreateEntry(Uri source)
+        {
+            return CreateEntry(source.AbsolutePath);
+        }
+
+        public Uri CreateEntry(string absolutePath)
+        {
+            var uri = new Uri($"{BaseAddress}{absolutePath}");
+            return uri;
+        }
+
+        public bool IsWhitelisted(HttpRequest request)
+        {
+            _logger?.LogDebug($"Whitelist.IsWhitelisted: {request.Path}");
+            if(request.Headers.TryGetForwardAddress(out var forwardTo))
+            {
+                if(Uri.TryCreate(forwardTo, UriKind.Absolute, out var forwardUri))
+                {
+                    _logger.LogTrace($"Checking whitelist on behalf of {forwardUri}");
+                    forwardUri = CreateEntry(forwardUri);
+                    if(Entries.Any(e=>e.IsBaseOf(forwardUri)))
+                    {
+                        _logger.LogTrace($"{forwardUri}:true");
+                        return true;
+                    }
+                    _logger.LogTrace($"{forwardUri}:false");
+                    return false;
+                }
+                else
+                {
+                    _logger.LogWarning("Unexpected content passed as header value; expected a valid Uri; enable tracing to view untrusted header values.");
+                    _logger.LogTrace($"Unexpected content passed as header value; expected a valid Uri; value={forwardTo};");
+
+                    throw new Exception("Could not construct valid Uri from forward address");
+                }
+            }
+            return false;
+        }
+    }
+}

--- a/src/RouteServiceAuth/WhitelistOptions.cs
+++ b/src/RouteServiceAuth/WhitelistOptions.cs
@@ -1,0 +1,13 @@
+﻿using System;
+using System.Collections.Generic;
+namespace RouteServiceAuth
+{
+    public class WhitelistOptions
+    {
+        public WhitelistOptions()
+        {
+        }
+
+        public List<string> Paths { get; private set; } = new List<string>();
+    }
+}

--- a/src/RouteServiceAuth/appsettings.json
+++ b/src/RouteServiceAuth/appsettings.json
@@ -1,11 +1,14 @@
 {
   "Logging": {
     "LogLevel": {
-      "Default": "Warning"
+      "Default": "Trace"
     },
     "Console": {
       "DisableColors": true
     }
   },
+  "Whitelist":[
+    "/cloudfoundryapplication"
+  ],
   "AllowedHosts": "*"
 }

--- a/src/RouteServiceAuth/appsettings.json
+++ b/src/RouteServiceAuth/appsettings.json
@@ -7,8 +7,13 @@
       "DisableColors": true
     }
   },
-  "Whitelist":[
-    "/cloudfoundryapplication"
-  ],
+  "Whitelist": {
+    "Paths": [
+      "/cloudfoundryapplication",
+      "/cloudfoundryapplication/",
+      "/actuator",
+      "/actuator/"
+    ]
+  },
   "AllowedHosts": "*"
 }

--- a/src/RouteServiceAuth/appsettings.json
+++ b/src/RouteServiceAuth/appsettings.json
@@ -9,7 +9,6 @@
   },
   "Whitelist": {
     "Paths": [
-      "/about",
       "/cloudfoundryapplication",
       "/cloudfoundryapplication/",
       "/actuator",

--- a/src/RouteServiceAuth/appsettings.json
+++ b/src/RouteServiceAuth/appsettings.json
@@ -9,6 +9,7 @@
   },
   "Whitelist": {
     "Paths": [
+      "/about",
       "/cloudfoundryapplication",
       "/cloudfoundryapplication/",
       "/actuator",

--- a/src/manifest.yml
+++ b/src/manifest.yml
@@ -1,6 +1,6 @@
 applications:
 - name: iwa-route-service
-  path: RouteServiceAuth/bin/Debug/netcoreapp2.2/publish
+  path: RouteServiceAuth/bin/Release/netcoreapp2.2/publish
   env:
     PRINCIPAL_PASSWORD: SomePassword
   instances: 1


### PR DESCRIPTION
Enabling windows auth for apps using the route service can inadvertently break actuators and therefore AppsMan integration.  By providing a whitelist capability we can ensure cloudfoundry endpoints continue to integrate with Apps Manager while kerberos is enabled for front-door access.